### PR TITLE
fix too many calls to 'emitMovement'

### DIFF
--- a/frontend/src/components/world/WorldMap.tsx
+++ b/frontend/src/components/world/WorldMap.tsx
@@ -187,10 +187,12 @@ class CoveyGameScene extends Phaser.Scene {
       const isMoving = primaryDirection !== undefined;
       this.player.label.setX(body.x);
       this.player.label.setY(body.y - 20);
-      if (!this.lastLocation
-        || this.lastLocation.x !== body.x
-        || this.lastLocation.y !== body.y || this.lastLocation.rotation !== primaryDirection
-        || this.lastLocation.moving !== isMoving) {
+      if (isMoving &&
+        ( !this.lastLocation
+          || this.lastLocation.x !== body.x
+          || this.lastLocation.y !== body.y
+          || this.lastLocation.rotation !== primaryDirection
+          || this.lastLocation.moving !== isMoving)) {
         if (!this.lastLocation) {
           this.lastLocation = {
             x: body.x,

--- a/frontend/src/components/world/WorldMap.tsx
+++ b/frontend/src/components/world/WorldMap.tsx
@@ -187,12 +187,11 @@ class CoveyGameScene extends Phaser.Scene {
       const isMoving = primaryDirection !== undefined;
       this.player.label.setX(body.x);
       this.player.label.setY(body.y - 20);
-      if (isMoving &&
-        ( !this.lastLocation
+      if (!this.lastLocation
           || this.lastLocation.x !== body.x
           || this.lastLocation.y !== body.y
-          || this.lastLocation.rotation !== primaryDirection
-          || this.lastLocation.moving !== isMoving)) {
+          || (isMoving && this.lastLocation.rotation !== primaryDirection)
+          || this.lastLocation.moving !== isMoving) {
         if (!this.lastLocation) {
           this.lastLocation = {
             x: body.x,

--- a/frontend/src/components/world/WorldMap.tsx
+++ b/frontend/src/components/world/WorldMap.tsx
@@ -188,10 +188,10 @@ class CoveyGameScene extends Phaser.Scene {
       this.player.label.setX(body.x);
       this.player.label.setY(body.y - 20);
       if (!this.lastLocation
-          || this.lastLocation.x !== body.x
-          || this.lastLocation.y !== body.y
-          || (isMoving && this.lastLocation.rotation !== primaryDirection)
-          || this.lastLocation.moving !== isMoving) {
+        || this.lastLocation.x !== body.x
+        || this.lastLocation.y !== body.y
+        || (isMoving && this.lastLocation.rotation !== primaryDirection)
+        || this.lastLocation.moving !== isMoving) {
         if (!this.lastLocation) {
           this.lastLocation = {
             x: body.x,


### PR DESCRIPTION
I was trying to debug our group's feature and I found that the game loop is flooding the socket with movement calls. Adding 'isMoving' into the conditional makes it so that socket messages are correctly emitted only after user input.

I found this issue by pasting 
`localStorage.debug = '*';`
in my chrome developer tools console.
https://stackoverflow.com/questions/8699225/socket-io-client-debugging