### PR TITLE
Enable reopening SelectVideoModal if it was closed without having to re-enter the area

### DIFF
--- a/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
+++ b/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@chakra-ui/react';
-import React,{ useEffect, useRef, useState } from 'react';
+import React,{ useEffect,useRef,useState } from 'react';
 import ReactPlayer from 'react-player';
-import { useInteractable, useViewingAreaController } from '../../../classes/TownController';
+import { useInteractable,useViewingAreaController } from '../../../classes/TownController';
 import ViewingAreaController from '../../../classes/ViewingAreaController';
 import useTownController from '../../../hooks/useTownController';
 import SelectVideoModal from './SelectVideoModal';
@@ -145,7 +145,7 @@ export function ViewingArea({
           // forces game to emit "viewingArea" event again so that
           // repoening the modal works as expected
           townController.interactEnd(viewingArea);
-        };}
+        }}
         viewingArea={viewingArea}
       />
     );

--- a/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
+++ b/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@chakra-ui/react';
-import React, { useEffect, useRef, useState } from 'react';
+import React,{ useEffect,useRef,useState } from 'react';
 import ReactPlayer from 'react-player';
-import { useInteractable, useViewingAreaController } from '../../../classes/TownController';
+import { useViewingAreaController } from '../../../classes/TownController';
 import ViewingAreaController from '../../../classes/ViewingAreaController';
 import useTownController from '../../../hooks/useTownController';
 import SelectVideoModal from './SelectVideoModal';
@@ -140,7 +140,12 @@ export function ViewingArea({
     return (
       <SelectVideoModal
         isOpen={selectIsOpen}
-        close={() => setSelectIsOpen(false)}
+        close={() => {
+          setSelectIsOpen(false);
+          // forces game to emit "viewingArea" event again so that
+          // repoening the modal works as expected
+          townController.interactEnd(viewingArea);
+        };}
         viewingArea={viewingArea}
       />
     );

--- a/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
+++ b/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
@@ -1,5 +1,5 @@
 import { Container } from '@chakra-ui/react';
-import React,{ useEffect,useRef,useState } from 'react';
+import React,{ useEffect, useRef, useState } from 'react';
 import ReactPlayer from 'react-player';
 import { useInteractable, useViewingAreaController } from '../../../classes/TownController';
 import ViewingAreaController from '../../../classes/ViewingAreaController';

--- a/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
+++ b/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@chakra-ui/react';
-import React,{ useEffect,useRef,useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactPlayer from 'react-player';
-import { useInteractable,useViewingAreaController } from '../../../classes/TownController';
+import { useInteractable, useViewingAreaController } from '../../../classes/TownController';
 import ViewingAreaController from '../../../classes/ViewingAreaController';
 import useTownController from '../../../hooks/useTownController';
 import SelectVideoModal from './SelectVideoModal';

--- a/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
+++ b/frontend/src/components/Town/interactables/ViewingAreaVideo.tsx
@@ -1,7 +1,7 @@
 import { Container } from '@chakra-ui/react';
 import React,{ useEffect,useRef,useState } from 'react';
 import ReactPlayer from 'react-player';
-import { useViewingAreaController } from '../../../classes/TownController';
+import { useInteractable, useViewingAreaController } from '../../../classes/TownController';
 import ViewingAreaController from '../../../classes/ViewingAreaController';
 import useTownController from '../../../hooks/useTownController';
 import SelectVideoModal from './SelectVideoModal';


### PR DESCRIPTION
Previously SelectVideoModal did not pop up again if the user closed the modal (by pressing "X") and pressed space again. 
This PR contains modifications to emit `endInteraction` when `onClose` of the modal is called